### PR TITLE
chore: allows saving given external id

### DIFF
--- a/Eloquent/NewModelBase.php
+++ b/Eloquent/NewModelBase.php
@@ -136,7 +136,7 @@ abstract class NewModelBase extends Model
             return;
         }
 
-        if ($this->hasExternalId) {
+        if ($this->hasExternalId && !$model->external_id) {
             $model->external_id = Uuid::uuid4()->toString();
         }
     }


### PR DESCRIPTION
Permite que caso um external_id seja informado, o model base não o sobrescreva.